### PR TITLE
Bugfix nexus read charset

### DIFF
--- a/src/itaxotools/concatenator/library/nexus.py
+++ b/src/itaxotools/concatenator/library/nexus.py
@@ -5,6 +5,7 @@ from typing import (
 from enum import Enum
 import tempfile
 import re
+import logging
 
 import pandas as pd
 
@@ -381,7 +382,8 @@ class NexusReader:
 
     def __init__(self) -> None:
         self.table = pd.DataFrame()
-        self.columns = ["seqid"]
+        # maps starts of charsets to their names, should only contain gene charsets
+        self.charsets: Dict[int, str] = {}
         self.state: Optional[NexusState] = None
         self.todo: Set[NexusState] = {NexusState.Data, NexusState.Sets}
         self.ntax: Optional[int] = None
@@ -491,12 +493,34 @@ class NexusReader:
         Adds charset name to self.columns
         """
         if self.state == NexusState.Sets:
-            try:
-                self.columns.append(next(args))
-            except StopIteration:
-                self.columns.append("")
+            args_tuple = tuple(args)
+            if len(args_tuple) != 3 or args_tuple[1] != "=":
+                raise ValueError(f"Invalid arguments for 'charset': {args_tuple}")
+            name, _, position = args_tuple
+            if '\\' in position:
+                return
+            start_s, hyphen, _ = position.partition('-')
+            if not (hyphen and start_s.isdigit()):
+                raise ValueError(f"Invalid charset position: {repr(position)}")
+            self.charsets[int(start_s)] = name
+
+    def columns(self) -> List[str]:
+        return (["seqid"] +
+                [self.charsets[position] for position in sorted(self.charsets.keys())])
 
     def return_table(self) -> pd.DataFrame:
         self.table.reset_index(inplace=True)
-        self.table.columns = self.columns
-        return self.table
+        columns = self.columns()
+        if len(self.table.columns) == len(columns):
+            self.table.columns = columns
+            return self.table
+        else:
+            logging.warning(
+                "Several blocks of sequences in interleaved format detected, "
+                "but character sets missing or wrongly specified. "
+                "All sequences will be read in as a single gene.")
+            concat_table = self.table.iloc[:, 0:1].copy()
+            if len(self.table.columns) >= 2:
+                concat_table['sequence_gene'] = (
+                    self.table.iloc[:, 1].str.cat(self.table.iloc[:, 2:]))
+            return concat_table


### PR DESCRIPTION
When reading a NEXUS file, the program will ignore the charsets corresponding to codons and use the names of charsets for the names of columns of generated table, in the order of starting position. If the number of charsets doesn't match the number of genes, all genes are concatenated. 