### PR TITLE
Update packages

### DIFF
--- a/packages.html
+++ b/packages.html
@@ -1,23 +1,31 @@
 <!DOCTYPE html>
 <html>
   <div name="itaxotools-common">
-    <a href="git+https://github.com/iTaxoTools/itt-common.git@e4e3589013e6#egg=itaxotools-common-0.2.0">
+    <a href="git+https://git@github.com/iTaxoTools/itt-common.git@e4e3589013e6#egg=itaxotools-common-0.2.0">
       itaxotools-common-0.2.0</a><br/>
-    <a href="git+https://github.com/iTaxoTools/itt-common.git@v0.2.1#egg=itaxotools-common-0.2.1">
+    <a href="git+https://git@github.com/iTaxoTools/itt-common.git@v0.2.1#egg=itaxotools-common-0.2.1">
       itaxotools-common-0.2.1</a><br/>
-    <a href="git+https://github.com/iTaxoTools/itt-common.git@main#egg=itaxotools-common-0.2.dev2">
+    <a href="git+https://git@github.com/iTaxoTools/itt-common.git@main#egg=itaxotools-common-0.2.dev2">
+      itaxotools-common-0.2.dev2</a><br/>
+    <a href="git+ssh://git@github.com/iTaxoTools/itt-common.git@main#egg=itaxotools-common-0.2.dev2">
       itaxotools-common-0.2.dev2</a><br/>
   </div>
   <div name="concatenator">
-    <a href="git+https://github.com/iTaxoTools/concatenator.git@reorganization#egg=concatenator-0.2.dev0">
+    <a href="git+https://git@github.com/iTaxoTools/concatenator.git@reorganization#egg=concatenator-0.2.dev0">
+      concatenator-0.2.dev0</a><br/>
+    <a href="git+ssh://git@github.com/iTaxoTools/concatenator.git@reorganization#egg=concatenator-0.2.dev0">
       concatenator-0.2.dev0</a><br/>
   </div>
   <div name="DNAconvert">
-    <a href="git+https://github.com/iTaxoTools/DNAconvert.git@reorganization#egg=DNAconvert-0.1.dev1">
+    <a href="git+https://git@github.com/iTaxoTools/DNAconvert.git@reorganization#egg=DNAconvert-0.1.dev1">
+      DNAconvert-0.1.dev1</a><br/>
+    <a href="git+ssh://git@github.com/iTaxoTools/DNAconvert.git@reorganization#egg=DNAconvert-0.1.dev1">
       DNAconvert-0.1.dev1</a><br/>
   </div>
   <div name="MAFFTpy">
-    <a href="git+https://github.com/iTaxoTools/MAFFTpy.git@main#egg=MAFFTpy-0.1.dev2">
+    <a href="git+https://git@github.com/iTaxoTools/MAFFTpy.git@main#egg=MAFFTpy-0.1.dev2">
+      MAFFTpy-0.1.dev2</a><br/>
+    <a href="git+ssh://git@github.com/iTaxoTools/MAFFTpy.git@main#egg=MAFFTpy-0.1.dev2">
       MAFFTpy-0.1.dev2</a><br/>
   </div>
 </html>


### PR DESCRIPTION
I updated `packages.html` to use both the `ssh` and `https` schemes for Git VCS. Pip will first try to use SSH, then switch to HTTPS if no matching key was found. I also specified the user to `git`, which makes authentication more straightforward.

Fixes #47